### PR TITLE
Separar importação de dados da criação da estrutura de banco de dados

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,47 @@
-run:build
-	@echo "Starting Server" && \
-	docker-compose up
-
 build:
-	@echo "Building Application" && \
+	@echo "Building Application"
 	docker-compose build
 
-import:
-	@echo "Starting Importing Data from csv" && \
-	docker-compose run web rake i
-
-test:
-	@echo "Starting Tests" && \
-	docker-compose run web rake test
+run:build
+	@echo "Starting Server"
+	docker-compose up -d
+	docker-compose logs --follow web
 
 bash:
-	@echo "Starting Application Bash" && \
+	@echo "Starting Application Bash"
 	docker-compose run web bash
+
+stop:
+	docker-compose stop
+
+ps:
+	docker-compose ps
+
+test:
+	@echo "Starting Tests"
+	docker-compose run web rake test
+
+db-start:
+	docker-compose up -d db
+
+db-console:db-start
+	@echo "Starting psql console..."
+	@docker-compose exec db psql -d test_db -U test
+
+db-reset:db-start
+	@echo "Cleaning up database..."
+	@docker-compose run web rake db:reset
+	@echo "Selecting count of institutions:"
+	@docker-compose exec -T db psql -d test_db -U test -c 'SELECT count(id) from institutions;'
+
+db-migrate:db-start
+	@echo "Migrating database structure"
+	@docker-compose run web rake db:migrate
+	@echo "Created the following entities in test_db database:"
+	@docker-compose exec -T db psql -d test_db -U test -c '\d'
+
+db-seed:db-migrate
+	@echo "Importing Data from CSV"
+	@docker-compose run web rake db:seed
+	@echo "Selecting count of inserted institutions:"
+	@docker-compose exec -T db psql -d test_db -U test -c 'SELECT count(id) from institutions;'

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,7 @@ build:
 
 run:build
 	@echo "Starting Server"
-	docker-compose up -d
-	docker-compose logs --follow web
+	docker-compose up
 
 bash:
 	@echo "Starting Application Bash"

--- a/README.md
+++ b/README.md
@@ -22,14 +22,9 @@ $ make build
 ```
 _The command **make build** takes a long time so it is recommended to use it only if you really need to change the Gemfile._
 
-# Execution
-To run the server, execute:
-```
-$ make run
-```
-
 # Import Data
-To have Companies and Research Centers available in the project you need to import their data from CSV files.
+To have Companies and Research Centers available in the project you need to
+import their data from CSV files.
 
 You can find such files in Aceleradora's Google Drive.
 
@@ -38,10 +33,28 @@ The CSV files should be located in:
   csv/files/company.csv
   csv/files/research_center.csv
 ```
-With the files in the right folder, you can run the import command (It is faster now, with postgres =D )
+
+With the files in the right folder, you can run the import
+command (It is faster now, with postgres =D )
 ```
-$ make import
+$ make db-seed
 ```
+
+# Execution
+
+_The database schema must be created before starting the application, or
+it will crash otherwise. To do so, you have two options:_
+
+- Run the command mentioned above, importing the data from the CSV files
+
+- Create the schema without any data, by running `make db-migrate`.
+
+Once you set up your schema, you can run the server with:
+
+```
+$ make run
+```
+
 # Browser
 Open browser in:
 ```
@@ -57,6 +70,44 @@ If you want to access application container bash (terminal), run the following c
 ```
 $ make bash
 ```
+
+# Database operations
+
+There are a few make targets that help with schema management with PostgreSQL
+in Docker:
+
+__Generate and/or migrate database schema__
+
+Which will run `DataMapper.auto_upgrade!`.
+
+```
+make db-migrate
+```
+
+__Reset database data and recreate schema__
+
+Which will run `DataMapper.auto_migrate!`.
+
+```
+make db-reset
+```
+
+__Access Postgres Client in a running Docker container__
+
+```
+make db-console
+```
+
+__Insert data from CSV files into a database
+(see Import Data section of this document to get some context)__
+
+```
+make db-seed
+```
+
+_Since some of the above operations require a previously started Psql container,
+they all execute `db-start`, which will start the psql container with
+Docker Compose._
 
 # Other informations
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,15 +1,31 @@
 require ::File.expand_path('../config/environment', __FILE__)
+require_relative 'csv/csv_import.rb'
 
 desc 'Start Development Server Locally'
-task "s" do
+
+task :s do
   fork do
     exec "compass watch"
   end
   exec "rerun --background 'rackup config.ru --port 9393 --host 0.0.0.0'"
 end
-task "i" do
-  exec "ruby csv/csv_import.rb"
+
+task :test do
+  exec "rspec --format d --color"
 end
-task "test" do
-  exec "rspec -fd -c"
+
+namespace :db do
+
+  task :migrate do
+    DataMapper.auto_upgrade!
+  end
+
+  task :reset do
+    DataMapper.auto_migrate!
+  end
+
+  task :seed do
+    CsvImport.run
+  end
+
 end

--- a/config/database.rb
+++ b/config/database.rb
@@ -1,7 +1,8 @@
 require 'data_mapper'
 require 'dm-core'
-require  'dm-migrations'
+require 'dm-migrations'
 require 'dm-validations'
+
 DataMapper::Property::String.length(255)
 
 configure :development do

--- a/csv/csv_import.rb
+++ b/csv/csv_import.rb
@@ -21,7 +21,7 @@ module CsvImport
 
     research_centers = CsvMappers.parse_research_center()
 
-    puts "Saving Companies"
+    puts "Saving Research Centers"
 
     research_centers.each_with_index do |center, index|
       center.insert_to_db

--- a/csv/csv_import.rb
+++ b/csv/csv_import.rb
@@ -1,24 +1,33 @@
-require 'sinatra'
-require_relative '../config/environment.rb'
-require_relative '../config/database.rb'
-require_relative 'csv_parser.rb'
-require_relative 'models/csv_lambdas.rb'
+require_relative 'csv_mappers.rb'
 
-DataMapper.auto_migrate!
+module CsvImport
 
-puts "Importing Companies..."
-company_csv_content = File.read(Dir.pwd + '/csv/files/company.csv')
-company_parser = CsvParser.new
-company_list = company_parser.parse(company_csv_content,CsvLambdas.company)
-puts "Saving Companies"
-company_list.each_with_index {|company, index| company.insert_to_db; puts "#{index + 1}/#{company_list.length}" }
+  def self.run
 
-puts "\n\n"
-puts "Importing Research Centsers..."
-research_center_csv_content = File.read(Dir.pwd + '/csv/files/research_center.csv')
-research_center_parser = CsvParser.new(:col_sep => '*')
-research_list = research_center_parser.parse(research_center_csv_content, CsvLambdas.research_center)
-puts "Saving Research Centers"
-research_list.each_with_index {|research_center, index| research_center.insert_to_db; puts "#{index + 1}/#{research_list.length}"  }
+    puts "Importing Companies..."
 
-Process.kill('TERM', Process.pid)
+    companies = CsvMappers.parse_company()
+
+    puts "Saving Companies"
+
+    companies.each_with_index do |company, index|
+      company.insert_to_db
+      puts "#{index + 1}/#{companies.length}"
+    end
+
+    puts "\n\n"
+
+    puts "Importing Research Centers..."
+
+    research_centers = CsvMappers.parse_research_center()
+
+    puts "Saving Companies"
+
+    research_centers.each_with_index do |center, index|
+      center.insert_to_db
+      puts "#{index + 1}/#{research_centers.length}"
+    end
+
+  end
+
+end

--- a/csv/csv_mappers.rb
+++ b/csv/csv_mappers.rb
@@ -1,0 +1,50 @@
+require 'pathname'
+require_relative '../config/environment.rb'
+require_relative '../config/database.rb'
+require_relative 'csv_parser.rb'
+require_relative 'models/csv_lambdas.rb'
+
+module CsvMappers
+
+  CSV_LOCATION = File.join(Dir.pwd, 'csv', 'files')
+  COMPANY_FILE_NAME = 'company.csv'
+  RESEARCH_CENTER_FILE_NAME = 'research_center.csv'
+
+  class CsvFileMapper
+
+    def initialize(file_name, parser, lambda_processor)
+      @file_name = file_name
+      @parser = parser
+      @lambda_processor = lambda_processor
+    end
+
+    def parse
+
+      file_path = Pathname.new(File.join(CSV_LOCATION, @file_name))
+
+      if !file_path.exist?
+        abort("#{@file_name} could not be found under #{file_path.to_s}. Did you forget to put it there?")
+      end
+
+      @parser.parse(File.read(file_path), @lambda_processor)
+    end
+
+  end
+
+  def self.parse_company
+    (CsvFileMapper.new(
+      COMPANY_FILE_NAME,
+      CsvParser.new,
+      CsvLambdas.company
+    )).parse()
+  end
+
+  def self.parse_research_center
+    (CsvFileMapper.new(
+      RESEARCH_CENTER_FILE_NAME,
+      CsvParser.new(:col_sep => '*'),
+      CsvLambdas.research_center
+    )).parse()
+  end
+
+end

--- a/public/stylesheets/css/section.css
+++ b/public/stylesheets/css/section.css
@@ -1,45 +1,5 @@
-/* line 1, ../sass/section.scss */
-.Section {
-  display: flex;
-  flex-direction: column;
-  width: 100;
-  min-height: 110vh;
-  /*background-image: url("https://static1.squarespace.com/static/55555e9be4b0cc5c1ed72f84/t/556f8657e4b0ad976216e5e7/1433372247762/business-banner.jpg?format=1500w");*/
-  background-image: url("/images/background-main.jpg");
-  background-size: cover;
-  background-attachment: fixed;
-}
-
-/* line 12, ../sass/section.scss */
-.SectionOpacity {
-  width: 100%;
-  height: 95vh;
-  background-color: rgba(0, 0, 0, 0.47);
-  display: flex;
-  flex-direction: column;
-}
-
-/* line 20, ../sass/section.scss */
-.Function {
-  display: flex;
-  width: 100%;
-  height: 85vh;
-  background: linear-gradient(rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8), rgba(0, 0, 0, 0.9));
-  background-size: cover;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-}
-
-/* line 32, ../sass/section.scss */
-.About {
-  display: flex;
-  width: 100%;
-  height: 80vh;
-  color: #ffffff;
-  background-color: rgba(44, 127, 171, 0.93);
-  background-size: cover;
-  flex-direction: column;
-  justify-content: center;
+/* line 1, ../sass/Section.scss */
+.SectionPrimary {
+  width: 100vw;
+  height: 100vh;
 }

--- a/public/stylesheets/sass/section.scss
+++ b/public/stylesheets/sass/section.scss
@@ -1,41 +1,4 @@
-.Section{
-	display: flex;
-	flex-direction: column;
-	width: 100;
-	min-height: 110vh;
-	/*background-image: url("https://static1.squarespace.com/static/55555e9be4b0cc5c1ed72f84/t/556f8657e4b0ad976216e5e7/1433372247762/business-banner.jpg?format=1500w");*/
-	background-image: url('/images/background-main.jpg');
-	background-size: cover;
-	background-attachment: fixed;
-
-}
-.SectionOpacity{
-	width: 100%;
-	height: 95vh;
-	background-color: rgba(0,0,0,0.47);
-	display: flex;
-
-	flex-direction: column;
-}
-.Function{
-	display: flex;
-	width: 100%;
-	height: 85vh;
-	background: linear-gradient(rgba(0,0,0,0.3),rgba(0,0,0,0.5),rgba(0,0,0,0.7), rgba(0,0,0,0.8),rgba(0,0,0,0.9) );
-	background-size: cover;
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-
-}
-.About{
-	display: flex;
-	width: 100%;
-	height: 80vh;
-	color: #ffffff;
-	background-color: rgba(44, 127, 171, 0.93);
-	background-size: cover;
-	flex-direction: column;
-	justify-content: center;
+.SectionPrimary{
+  width: 100vw;
+  height: 100vh;
 }


### PR DESCRIPTION
Houveram as seguintes mudanças nesta PR:

__O script de importação foi refatorado__

Ele está um pouco mais simples e vai nos permitir tentar começar a testar as coisas unitariamente (eu acho, ainda preciso estudar mais um pouco pra afirmar isso hehehehe).

__A criação da estrutura do banco de dados foi separada do script de importação__

Isso significa que é possível criar um banco de dados vazio, resetar os dados e reimportá-los de forma separada, evitando que a aplicação sempre quebre quando os CSVs não são importados.

__Novas tasks no Rakefile e Makefile__

Estas tasks servem para gerenciar os ciclos de criação e manipulação da estrutura do banco de dados

__O script de importação CSV [falha graciosamente](https://en.wikipedia.org/wiki/Graceful_exit) na ausência dos arquivos necessários__

Dessa forma, é possível ver, de maneira explícita, uma mensagem de erro com o motivo da falha na importação.

__É possível acessar o banco de dados rodando no docker__

Com `make db-console`, abre-se um cliente `psql` para o banco de dados rodando localmente em um container do Docker.

# À título de curiosidade

Ao inserir 200 `institutions` no banco de dados, a aplicação não consegue responder. Acho que precisamos revisar a modelagem do banco, pois parece que isso não se trata mais de um simples gargalo de performance, mas sim da degradação completa da aplicação com um volume minimamente maior de dados.